### PR TITLE
Fix module path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@lemonsqueezy/lemonsqueezy.js",
   "description": "The official Lemon Squeezy JavaScript SDK.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Lemon Squeezy",
   "license": "MIT",
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/index.js",
   "homepage": "https://github.com/lmsqueezy/lemonsqueezy.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request updates the version number in package.json from 1.2.1 to 1.2.2 and changes the module path from dist/index.mjs to dist/index.js.