### PR TITLE
fix: improve `FetchResponse` typing

### DIFF
--- a/src/internal/fetch/index.ts
+++ b/src/internal/fetch/index.ts
@@ -14,7 +14,8 @@ export async function $fetch<T>(options: FetchOptions, needApiKey = true) {
   const response: FetchResponse<T> = {
     statusCode: null,
     data: null,
-    error: null,
+    // We use `null as unknown as Error` because `FetchResponse` doesn't allow both `data` and `error` to be `null`.
+    error: null as unknown as Error,
   };
   const { apiKey, onError } = getKV<Config>(CONFIG_KEY) || {};
 

--- a/src/internal/fetch/types.ts
+++ b/src/internal/fetch/types.ts
@@ -1,11 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type ApiVersion = "v1";
 
-export type FetchResponse<T> = {
-  statusCode: number | null;
-  data: T | null;
-  error: Error | null;
-};
+export type FetchResponse<T> =
+  | {
+      statusCode: number;
+      data: T;
+      error: null;
+    }
+  | {
+      statusCode: number | null;
+      data: null;
+      error: Error;
+    };
 
 export type FetchOptions = {
   /**


### PR DESCRIPTION
![image](https://github.com/lmsqueezy/lemonsqueezy.js/assets/74945038/24f82a51-8433-4d9a-8d7d-d38dc40ea8c9)
here's an image explaining how it can provide better typings. Once u make sure there's no error, it'll allow u to safely access the data prop