### PR TITLE
Fixed the `getSubscriptionItem` function does not check `subscriptionItemId` as a required parameter.

### DIFF
--- a/src/subscriptionItems/index.ts
+++ b/src/subscriptionItems/index.ts
@@ -27,6 +27,7 @@ export function getSubscriptionItem(
   subscriptionItemId: number | string,
   params: GetSubscriptionItemParams = {}
 ) {
+  requiredCheck({ subscriptionItemId });
   return $fetch<SubscriptionItem>({
     path: `/v1/subscription-items/${subscriptionItemId}${convertIncludeToQueryString(params.include)}`,
   });


### PR DESCRIPTION
Fixed the `getSubscriptionItem` function does not check `subscriptionItemId` as a required parameter.