### PR TITLE
fix: `updateSubscription` `pause` should be nullable according to DocString

### DIFF
--- a/.changeset/quick-planets-know.md
+++ b/.changeset/quick-planets-know.md
@@ -1,0 +1,5 @@
+---
+"@lemonsqueezy/lemonsqueezy.js": patch
+---
+
+Made `UpdateSubscription`.`pause` nullable

--- a/src/subscriptions/types.ts
+++ b/src/subscriptions/types.ts
@@ -288,7 +288,7 @@ export type UpdateSubscription = Partial<{
   pause: {
     mode: "void" | "free";
     resumesAt?: string | null;
-  };
+  } | null;
   /**
    * Set as `true` to cancel the subscription. You can resume a subscription (before the `ends_at` date) by setting this to `false`.
    */


### PR DESCRIPTION
Citing the DocString for the `UpdateSubscription` type:
> You can set the pause object to `null` to unpause the subscription.

Currently the `pause` property does not accept `null` as a valid value.