### PR TITLE
Add `expiresAt` to `updateLicenseKey` function

### DIFF
--- a/.changeset/great-kangaroos-dance.md
+++ b/.changeset/great-kangaroos-dance.md
@@ -1,0 +1,5 @@
+---
+"@lemonsqueezy/lemonsqueezy.js": patch
+---
+
+Add `expiresAt` to `updateLicenseKey` function

--- a/src/licenseKeys/index.ts
+++ b/src/licenseKeys/index.ts
@@ -58,6 +58,7 @@ export function listLicenseKeys(params: ListLicenseKeysParams = {}) {
  * @param licenseKeyId The license key id.
  * @param licenseKey (Optional) Values to be updated.
  * @param [licenseKey.activationLimit] (Optional) The activation limit of this license key. Assign `null` to set the activation limit to "unlimited".
+ * @param [licenseKey.expiresAt] (Optional) An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted date-time string indicating when the license key expires. Can be `null` if the license key is perpetual.
  * @param [licenseKey.disabled] (Optional) If `true`, the license key will have "disabled" status.
  * @returns A license key object.
  */
@@ -67,8 +68,8 @@ export function updateLicenseKey(
 ) {
   requiredCheck({ licenseKeyId });
 
-  const { activationLimit, disabled = false } = licenseKey;
-  const attributes = convertKeys({ activationLimit, disabled });
+  const { activationLimit, disabled = false, expiresAt } = licenseKey;
+  const attributes = convertKeys({ activationLimit, disabled, expiresAt });
 
   return $fetch<LicenseKey>({
     path: `/v1/license-keys/${licenseKeyId}`,

--- a/src/licenseKeys/types.ts
+++ b/src/licenseKeys/types.ts
@@ -135,6 +135,10 @@ export type UpdateLicenseKey = {
    */
   activationLimit?: number | null;
   /**
+   * An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted date-time string indicating when the license key expires. Can be `null` if the license key is perpetual.
+   */
+  expiresAt?: string | null;
+  /**
    * If `true`, the license key will have "disabled" status.
    */
   disabled?: boolean;

--- a/test/licenseKeys/index.test.ts
+++ b/test/licenseKeys/index.test.ts
@@ -446,13 +446,14 @@ describe("Update a license key", () => {
     }
   });
 
-  it("Should return a license key object with activation_limit is 5", async () => {
+  it("Should return a license key object with activation_limit is 5 and disabled is false", async () => {
     const newActivationLimit = 5;
     const {
       statusCode,
       error,
       data: _data,
     } = await updateLicenseKey(licenseKeyId, {
+      disabled: false,
       activationLimit: newActivationLimit,
     });
     expect(statusCode).toEqual(200);
@@ -515,6 +516,188 @@ describe("Update a license key", () => {
     expect(order_item_id).toEqual(Number(orderItemId));
     expect(product_id).toEqual(Number(productId));
     expect(activation_limit).toEqual(newActivationLimit);
+
+    const {
+      store,
+      customer,
+      order,
+      "order-item": orderItem,
+      product,
+      "license-key-instances": licenseKeyInstances,
+    } = relationships;
+    const relationshipItems = [
+      store,
+      customer,
+      order,
+      orderItem,
+      product,
+      licenseKeyInstances,
+    ];
+    for (const item of relationshipItems) expect(item).toBeDefined();
+    expect(Object.keys(relationships).length).toEqual(relationshipItems.length);
+  });
+
+  it("Should return a license key object with expires_at is null", async () => {
+    const {
+      statusCode,
+      error,
+      data: _data,
+    } = await updateLicenseKey(licenseKeyId, {
+      expiresAt: null,
+    });
+    expect(statusCode).toEqual(200);
+    expect(error).toBeNull();
+    expect(_data).toBeDefined();
+
+    const { data, links } = _data!;
+    expect(links.self).toEqual(`${API_BASE_URL}${PATH}${licenseKeyId}`);
+
+    const { type, id, attributes, relationships } = data;
+    expect(type).toEqual(DATA_TYPE);
+    expect(id).toEqual(licenseKeyId.toString());
+    expect(attributes).toBeDefined();
+    expect(relationships).toBeDefined();
+
+    const {
+      store_id,
+      customer_id,
+      order_id,
+      order_item_id,
+      product_id,
+      status,
+      key,
+      user_name,
+      user_email,
+      key_short,
+      activation_limit,
+      instances_count,
+      disabled,
+      status_formatted,
+      expires_at,
+      created_at,
+      updated_at,
+      test_mode,
+    } = attributes;
+    const items = [
+      store_id,
+      customer_id,
+      order_id,
+      order_item_id,
+      product_id,
+      status,
+      key,
+      user_name,
+      user_email,
+      key_short,
+      activation_limit,
+      instances_count,
+      disabled,
+      status_formatted,
+      expires_at,
+      created_at,
+      updated_at,
+      test_mode,
+    ];
+    for (const item of items) expect(item).toBeDefined();
+    expect(Object.keys(attributes).length).toEqual(items.length);
+    expect(store_id).toEqual(Number(storeId));
+    expect(order_id).toEqual(Number(orderId));
+    expect(order_item_id).toEqual(Number(orderItemId));
+    expect(product_id).toEqual(Number(productId));
+    expect(expires_at).toBeNull();
+
+    const {
+      store,
+      customer,
+      order,
+      "order-item": orderItem,
+      product,
+      "license-key-instances": licenseKeyInstances,
+    } = relationships;
+    const relationshipItems = [
+      store,
+      customer,
+      order,
+      orderItem,
+      product,
+      licenseKeyInstances,
+    ];
+    for (const item of relationshipItems) expect(item).toBeDefined();
+    expect(Object.keys(relationships).length).toEqual(relationshipItems.length);
+  });
+
+  it("Should return a license key object with expires_at is 2024-05-26", async () => {
+    const date = new Date(new Date().getTime() + 86400000)
+      .toISOString()
+      .split("T")[0];
+    const expiresAt = `${date}T00:00:00.000000Z`;
+    const {
+      statusCode,
+      error,
+      data: _data,
+    } = await updateLicenseKey(licenseKeyId, {
+      expiresAt,
+    });
+    expect(statusCode).toEqual(200);
+    expect(error).toBeNull();
+    expect(_data).toBeDefined();
+
+    const { data, links } = _data!;
+    expect(links.self).toEqual(`${API_BASE_URL}${PATH}${licenseKeyId}`);
+
+    const { type, id, attributes, relationships } = data;
+    expect(type).toEqual(DATA_TYPE);
+    expect(id).toEqual(licenseKeyId.toString());
+    expect(attributes).toBeDefined();
+    expect(relationships).toBeDefined();
+
+    const {
+      store_id,
+      customer_id,
+      order_id,
+      order_item_id,
+      product_id,
+      status,
+      key,
+      user_name,
+      user_email,
+      key_short,
+      activation_limit,
+      instances_count,
+      disabled,
+      status_formatted,
+      expires_at,
+      created_at,
+      updated_at,
+      test_mode,
+    } = attributes;
+    const items = [
+      store_id,
+      customer_id,
+      order_id,
+      order_item_id,
+      product_id,
+      status,
+      key,
+      user_name,
+      user_email,
+      key_short,
+      activation_limit,
+      instances_count,
+      disabled,
+      status_formatted,
+      expires_at,
+      created_at,
+      updated_at,
+      test_mode,
+    ];
+    for (const item of items) expect(item).toBeDefined();
+    expect(Object.keys(attributes).length).toEqual(items.length);
+    expect(store_id).toEqual(Number(storeId));
+    expect(order_id).toEqual(Number(orderId));
+    expect(order_item_id).toEqual(Number(orderItemId));
+    expect(product_id).toEqual(Number(productId));
+    expect(expires_at).toEqual(expiresAt);
 
     const {
       store,


### PR DESCRIPTION
### API Changelog
**April 9th, 2024**
- You now can modify the `expires_at` value using the [update License Key API endpoint](https://docs.lemonsqueezy.com/api/license-keys#update-a-license-key) to adjust the expiration date for existing License Keys.