### PR TITLE
Fix spelling error in Attributes type in src/subscriptions/types

### DIFF
--- a/src/subscriptions/types.ts
+++ b/src/subscriptions/types.ts
@@ -202,7 +202,7 @@ type Attributes = {
    */
   renews_at: string;
   /**
-   * f the subscription has as `status` of `cancelled` or `expired`, this will be an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted date-time string indicating when the subscription expires (or expired). For all other `status` values, this will be `null`.
+   * If the subscription has as `status` of `cancelled` or `expired`, this will be an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted date-time string indicating when the subscription expires (or expired). For all other `status` values, this will be `null`.
    */
   ends_at: string | null;
   /**


### PR DESCRIPTION
Corrected a minor spelling error in the Attributes type within src/subscriptions/types. Specifically, the word "f" was changed to "If" to ensure accurate documentation and code readability. This change helps maintain code quality and consistency.