### PR TITLE
Include `fraudulent` in Order `status` type

### DIFF
--- a/.changeset/tall-donuts-sort.md
+++ b/.changeset/tall-donuts-sort.md
@@ -1,0 +1,5 @@
+---
+"@lemonsqueezy/lemonsqueezy.js": patch
+---
+
+Include `fraudulent` in Order `status` type

--- a/src/orders/types.ts
+++ b/src/orders/types.ts
@@ -8,7 +8,7 @@ import type {
   Relationships,
 } from "../types";
 
-type OrderStatus = "pending" | "failed" | "paid" | "refunded";
+type OrderStatus = "pending" | "failed" | "paid" | "refunded" | "fraudulent";
 
 type FirstOrderItem = {
   /**
@@ -169,6 +169,7 @@ type Attributes = {
    * - `failed`
    * - `paid`
    * - `refunded`
+   * - `fraudulent`
    */
   status: OrderStatus;
   /**


### PR DESCRIPTION
As per [recent API change](https://docs.lemonsqueezy.com/api/changelog), Order `status` attribute now includes `fraudulent` status that indicates that the order has been marked as fraudulent. 