### PR TITLE
Make the address fields required for generate invoice

### DIFF
--- a/.changeset/lazy-carrots-smoke.md
+++ b/.changeset/lazy-carrots-smoke.md
@@ -1,0 +1,5 @@
+---
+"@lemonsqueezy/lemonsqueezy.js": major
+---
+
+Make the address fields required when generating invoices

--- a/src/orders/index.ts
+++ b/src/orders/index.ts
@@ -56,19 +56,20 @@ export function listOrders(params: ListOrdersParams = {}) {
  * Generate order invoice.
  *
  * @param orderId The given order id.
- * @param [params] (Optional) The given parameters.
- * @param [params.name] (Optional) The full name of the customer.
- * @param [params.address] (Optional) The street address of the customer.
- * @param [params.city] (Optional) The city of the customer.
- * @param [params.state] (Optional) The state of the customer.
- * @param [params.zipCode] (Optional) The ZIP code of the customer.
- * @param [params.country] (Optional) The country of the customer.
+ * @param [params] The given parameters.
+ * @param [params.name] The full name of the customer.
+ * @param [params.address] The street address of the customer.
+ * @param [params.city] The city of the customer.
+ * @param [params.state] The state of the customer.
+ * @param [params.zipCode] The ZIP code of the customer.
+ * @param [params.country] The country of the customer.
  * @param [params.notes] (Optional) Any additional notes to include on the invoice.
+ * @param [params.locale] (Optional) ISO 639 language code, e.g., ‘en’ for English language.
  * @returns A link to download the generated invoice.
  */
 export function generateOrderInvoice(
   orderId: number | string,
-  params: GenerateOrderInvoiceParams = {}
+  params: GenerateOrderInvoiceParams
 ) {
   requiredCheck({ orderId });
   const searchParams = convertKeys(params);

--- a/src/orders/types.ts
+++ b/src/orders/types.ts
@@ -1,6 +1,7 @@
 import type {
   Data,
   ISO4217CurrencyCode,
+  LanguageCode,
   LemonSqueezyResponse,
   Links,
   Meta,
@@ -272,33 +273,37 @@ export type ListOrdersParams = Params<
 
 export type GenerateOrderInvoiceParams = {
   /**
-   * Optional. The full name of the customer.
+   * The full name of the customer.
    */
-  name?: string;
+  name: string;
   /**
-   * Optional. The street address of the customer.
+   * The street address of the customer.
    */
-  address?: string;
+  address: string;
   /**
-   * Optional. The city of the customer.
+   * The city of the customer.
    */
-  city?: string;
+  city: string;
   /**
-   * Optional. The state of the customer.
+   * The state of the customer. Required if the country is the United States or Canada.
    */
   state?: string;
   /**
-   * Optional. The ZIP code of the customer.
+   * The ZIP code of the customer.
    */
-  zipCode?: number;
+  zipCode: number;
   /**
-   * Optional. The country of the customer.
+   * The country of the customer.
    */
-  country?: string;
+  country: string;
   /**
    * Optional. Any additional notes to include on the invoice.
    */
   notes?: string;
+  /**
+   * Optional. The locale to use for the invoice. Defaults to 'en' locale.
+   */
+  locale?: LanguageCode;
 };
 
 export type Order = Omit<

--- a/src/subscriptionInvoices/index.ts
+++ b/src/subscriptionInvoices/index.ts
@@ -59,19 +59,20 @@ export function listSubscriptionInvoices(
  * Generate subscription invoice.
  *
  * @param subscriptionInvoiceId The given subscription invoice id.
- * @param [params] (Optional) Then given parameters.
- * @param [params.name] (Optional) The full name of the customer.
- * @param [params.address] (Optional) The street address of the customer.
- * @param [params.city] (Optional) The city of the customer.
- * @param [params.state] (Optional) The state of the customer.
- * @param [params.zipCode] (Optional) The ZIP code of the customer.
- * @param [params.country] (Optional) The country of the customer.
+ * @param [params] The given parameters.
+ * @param [params.name] The full name of the customer.
+ * @param [params.address] The street address of the customer.
+ * @param [params.city] The city of the customer.
+ * @param [params.state] The state of the customer.
+ * @param [params.zipCode] The ZIP code of the customer.
+ * @param [params.country] The country of the customer.
  * @param [params.notes] (Optional) Any additional notes to include on the invoice.
+ * @param [params.locale] (Optional) ISO 639 language code, e.g., ‘en’ for English language.
  * @returns A link to download the generated invoice.
  */
 export function generateSubscriptionInvoice(
   subscriptionInvoiceId: number | string,
-  params: GenerateSubscriptionInvoiceParams = {}
+  params: GenerateSubscriptionInvoiceParams
 ) {
   requiredCheck({ subscriptionInvoiceId });
   const searchParams = convertKeys(params);

--- a/src/subscriptionInvoices/types.ts
+++ b/src/subscriptionInvoices/types.ts
@@ -1,6 +1,7 @@
 import type {
   Data,
   ISO4217CurrencyCode,
+  LanguageCode,
   LemonSqueezyResponse,
   Links,
   Meta,
@@ -215,33 +216,37 @@ export type ListSubscriptionInvoicesParams = Params<
 >;
 export type GenerateSubscriptionInvoiceParams = {
   /**
-   * Optional. The full name of the customer.
+   * The full name of the customer.
    */
-  name?: string;
+  name: string;
   /**
-   * Optional. The street address of the customer.
+   * The street address of the customer.
    */
-  address?: string;
+  address: string;
   /**
-   * Optional. The city of the customer.
+   * The city of the customer.
    */
-  city?: string;
+  city: string;
   /**
-   * Optional. The state of the customer.
+   * The state of the customer. Required if the country is the United States or Canada.
    */
   state?: string;
   /**
-   * Optional. The ZIP code of the customer.
+   * The ZIP code of the customer.
    */
-  zipCode?: number;
+  zipCode: number;
   /**
-   * Optional. The country of the customer.
+   * The country of the customer.
    */
-  country?: string;
+  country: string;
   /**
    * Optional. Any additional notes to include on the invoice.
    */
   notes?: string;
+  /**
+   * Optional. The locale to use for the invoice. Defaults to 'en' locale.
+   */
+  locale?: LanguageCode;
 };
 export type SubscriptionInvoice = Omit<
   LemonSqueezyResponse<SubscriptionInvoiceData, unknown, Pick<Links, "self">>,

--- a/src/types/iso.ts
+++ b/src/types/iso.ts
@@ -435,3 +435,193 @@ export type ISO4217CurrencyCode =
   | "YER"
   | "ZAR"
   | "ZMW";
+
+/**
+ * ISO 639-1 Language Codes
+ *
+ * https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes#ISO_639-1
+ */
+export type LanguageCode =
+  | "aa" // Afar
+  | "ab" // Abkhaz
+  | "ae" // Avestan
+  | "af" // Afrikaans
+  | "ak" // Akan
+  | "am" // Amharic
+  | "an" // Aragonese
+  | "ar" // Arabic
+  | "as" // Assamese
+  | "av" // Avaric
+  | "ay" // Aymara
+  | "az" // Azerbaijani
+  | "ba" // Bashkir
+  | "be" // Belarusian
+  | "bg" // Bulgarian
+  | "bi" // Bislama
+  | "bm" // Bambara
+  | "bn" // Bengali
+  | "bo" // Tibetan
+  | "br" // Breton
+  | "bs" // Bosnian
+  | "ca" // Catalan
+  | "ce" // Chechen
+  | "ch" // Chamorro
+  | "co" // Corsican
+  | "cr" // Cree
+  | "cs" // Czech
+  | "cu" // Old Church Slavonic
+  | "cv" // Chuvash
+  | "cy" // Welsh
+  | "da" // Danish
+  | "de" // German
+  | "dv" // Divehi
+  | "dz" // Dzongkha
+  | "ee" // Ewe
+  | "el" // Greek
+  | "en" // English
+  | "eo" // Esperanto
+  | "es" // Spanish
+  | "et" // Estonian
+  | "eu" // Basque
+  | "fa" // Persian
+  | "ff" // Fula
+  | "fi" // Finnish
+  | "fj" // Fijian
+  | "fo" // Faroese
+  | "fr" // French
+  | "fy" // Western Frisian
+  | "ga" // Irish
+  | "gd" // Scottish Gaelic
+  | "gl" // Galician
+  | "gn" // Guaraní
+  | "gu" // Gujarati
+  | "gv" // Manx
+  | "ha" // Hausa
+  | "he" // Hebrew
+  | "hi" // Hindi
+  | "ho" // Hiri Motu
+  | "hr" // Croatian
+  | "ht" // Haitian
+  | "hu" // Hungarian
+  | "hy" // Armenian
+  | "hz" // Herero
+  | "ia" // Interlingua
+  | "id" // Indonesian
+  | "ie" // Interlingue
+  | "ig" // Igbo
+  | "ii" // Nuosu
+  | "ik" // Inupiaq
+  | "io" // Ido
+  | "is" // Icelandic
+  | "it" // Italian
+  | "iu" // Inuktitut
+  | "ja" // Japanese
+  | "jv" // Javanese
+  | "ka" // Georgian
+  | "kg" // Kongo
+  | "ki" // Kikuyu
+  | "kj" // Kwanyama
+  | "kk" // Kazakh
+  | "kl" // Kalaallisut
+  | "km" // Khmer
+  | "kn" // Kannada
+  | "ko" // Korean
+  | "kr" // Kanuri
+  | "ks" // Kashmiri
+  | "ku" // Kurdish
+  | "kv" // Komi
+  | "kw" // Cornish
+  | "ky" // Kyrgyz
+  | "la" // Latin
+  | "lb" // Luxembourgish
+  | "lg" // Ganda
+  | "li" // Limburgish
+  | "ln" // Lingala
+  | "lo" // Lao
+  | "lt" // Lithuanian
+  | "lu" // Luba-Katanga
+  | "lv" // Latvian
+  | "mg" // Malagasy
+  | "mh" // Marshallese
+  | "mi" // Māori
+  | "mk" // Macedonian
+  | "ml" // Malayalam
+  | "mn" // Mongolian
+  | "mr" // Marathi
+  | "ms" // Malay
+  | "mt" // Maltese
+  | "my" // Burmese
+  | "na" // Nauru
+  | "nb" // Norwegian Bokmål
+  | "nd" // Northern Ndebele
+  | "ne" // Nepali
+  | "ng" // Ndonga
+  | "nl" // Dutch
+  | "nn" // Norwegian Nynorsk
+  | "no" // Norwegian
+  | "nr" // Southern Ndebele
+  | "nv" // Navajo
+  | "ny" // Chichewa
+  | "oc" // Occitan
+  | "oj" // Ojibwe
+  | "om" // Oromo
+  | "or" // Oriya
+  | "os" // Ossetian
+  | "pa" // Panjabi
+  | "pi" // Pāli
+  | "pl" // Polish
+  | "ps" // Pashto
+  | "pt" // Portuguese
+  | "qu" // Quechua
+  | "rm" // Romansh
+  | "rn" // Kirundi
+  | "ro" // Romanian
+  | "ru" // Russian
+  | "rw" // Kinyarwanda
+  | "sa" // Sanskrit
+  | "sc" // Sardinian
+  | "sd" // Sindhi
+  | "se" // Northern Sami
+  | "sg" // Sango
+  | "si" // Sinhala
+  | "sk" // Slovak
+  | "sl" // Slovenian
+  | "sm" // Samoan
+  | "sn" // Shona
+  | "so" // Somali
+  | "sq" // Albanian
+  | "sr" // Serbian
+  | "ss" // Swati
+  | "st" // Southern Sotho
+  | "su" // Sundanese
+  | "sv" // Swedish
+  | "sw" // Swahili
+  | "ta" // Tamil
+  | "te" // Telugu
+  | "tg" // Tajik
+  | "th" // Thai
+  | "ti" // Tigrinya
+  | "tk" // Turkmen
+  | "tl" // Tagalog
+  | "tn" // Tswana
+  | "to" // Tonga
+  | "tr" // Turkish
+  | "ts" // Tsonga
+  | "tt" // Tatar
+  | "tw" // Twi
+  | "ty" // Tahitian
+  | "ug" // Uyghur
+  | "uk" // Ukrainian
+  | "ur" // Urdu
+  | "uz" // Uzbek
+  | "ve" // Venda
+  | "vi" // Vietnamese
+  | "vo" // Volapük
+  | "wa" // Walloon
+  | "wo" // Wolof
+  | "xh" // Xhosa
+  | "yi" // Yiddish
+  | "yo" // Yoruba
+  | "za" // Zhuang
+  | "zh" // Chinese
+  | "zu"; // Zulu


### PR DESCRIPTION
As per [Orders](https://docs.lemonsqueezy.com/api/orders/generate-order-invoice) and [Subscription Invoices](https://docs.lemonsqueezy.com/api/subscription-invoices/generate-subscription-invoice) docs, the address fields are now required when generating invoices.