### PR TITLE
add `subscription_plan_changed` hook to webhook event types

### DIFF
--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -21,6 +21,7 @@ type Events =
   | "subscription_payment_failed"
   | "subscription_payment_recovered"
   | "subscription_payment_refunded"
+  | "subscription_plan_changed"
   | "license_key_created"
   | "license_key_updated";
 


### PR DESCRIPTION
Despite being very useful for SaaS subscription management, this webhook event name is not listed in the lemonsqueezy library nor in the documentation for some reason. Yet the webhook is supported by Lemon Squeezy as you can enable it in the app dashboard (see screenshot below):

![image](https://github.com/user-attachments/assets/9f4c171c-aae2-4297-8f53-6aa12f506099)


Could the documentation be updated as well to include this event?

Thanks!